### PR TITLE
Helm Chart corrections and additions

### DIFF
--- a/charts/kubectyl/Chart.yaml
+++ b/charts/kubectyl/Chart.yaml
@@ -25,6 +25,8 @@ dependencies:
 - name: mariadb
   version: "11.3.0"
   repository: https://charts.bitnami.com/bitnami
+  condition: mariadb.create
 - name: redis
   version: "17.3.11"
   repository: https://charts.bitnami.com/bitnami
+  condition: redis.create

--- a/charts/kubectyl/README.md
+++ b/charts/kubectyl/README.md
@@ -1,0 +1,94 @@
+# Kubectyl Panel And Kuber Helm Chart
+
+## Configuration
+
+### Global Values
+
+| Key  | Type | Default | Description |
+| :--: | :-----------------: | :-----: | ----------- |
+| `global.timezone` | `string` | `UTC` | Timezone for the panel. |
+
+---
+
+### Ingress
+
+| Key  | Type | Default | Description |
+| :--: | :-----------------: | :-----: | ----------- |
+| `ingress.class` | `string` | `nginx` | The Ingress class for routing external traffic to services. |
+| `ingress.panel` | `string` | `panel.example.com` | The full FQDN that your panel will be accessible at. |
+| `ingress.kuber` | `string` | `kuber.example.com` | The full FQDN that the kuber daemon will be accessible at. |
+| `ingress.tls.create` | `bool` | `true` | Boolean to control if the chart should manage the creation of the Certificate resources. This is particularly useful if you have automation around Ingress resources that creates Certificates already. |
+| `ingress.tls.clusterIssuer` | `string` | `letsencrypt-prod` | Name of the ClusterIssuer that should be specified on the Ingress resources to create your certificate. Required for most configurations even if not managing the certificate in this chart. |
+| `ingress.annotations` | `map(string\|int\|bool)` | `{}` | Map of additional annotations to add to the Ingress resources. |
+
+---
+
+### Panel
+
+| Key  | Type | Default | Description |
+| :--: | :-----------------: | :-----: | ----------- |
+| `panel.image` | `string` | `quay.io/kubectyl/panel:develop` | The image for the Panel application container. |
+| `panel.storageClass` | `string` | `""` | The storage class to use for panel's persistent volume. To use default K8s storage class set this value to "". **This is mutually exclusive with `existingVolumeClaim` and should not be used with it.** |
+| `panel.existingVolumeClaim` | `string` | `""` | Name of existing volume claim resource to use for the pod volumes. **This is mutually exclusive with `storageClass` and should not be used with it.** |
+| `panel.email` | `string` | `abc@example.com` | The email address for Letsencrypt. Used for panel only as a reference to enable cert-manager. |
+| `panel.serviceAnnotations` | `map(string\|int\|bool)` | `{}` | Map of additional annotations to add to the panel's Service resource. |
+| `panel.statefulSetAnnotations` | `map(string\|int\|bool)` | `{}` | Map of additional annotations to add to the panel's StatefulSet resource. |
+
+---
+
+### Kuber
+
+| Key  | Type | Default | Description |
+| :--: | :-----------------: | :-----: | ----------- |
+| `kuber.image` | `string` | `quay.io/kubectyl/kuber:deveop` | The image for the Kuber application container. |
+| `kuber.replicaCount` | `int` | `0` | Set to 0. Will be automatically set to 1 by panel after installation. |
+| `kuber.serviceAnnotations` | `map(string\|int\|bool)` | `{}` | Map of additional annotations to add to kuber's Service resource. |
+| `kuber.deploymentAnnotations` | `map(string\|int\|bool)` | `{}` | Map of additional annotations to add to kuber's Deployment resource. |
+
+---
+
+### MariaDB
+
+| Key  | Type | Default | Description |
+| :--: | :-----------------: | :-----: | ----------- |
+| `mariadb.create` | `bool` | `true` | Boolean to control creation of mariadb chart resources. Useful if you plan on using an external mariadb instance. |
+| `mariadb.global.storageClass` | `string` | `""` | The storage class to use for mariadb's persistent volume. To use default K8s storage class set this value to "". |
+| `mariadb.externalHost` | `string` | `""` | Hostname of external mariadb instance if you intend to use one. If using built-in mariadb chart, leave this blank or don't include it at all. |
+| `mariadb.volumePermissions.enabled` | `bool` | `true` | Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup`. |
+| `mariadb.image.debug` | `bool` | `true` | Boolean to control if debug logs should be enabled. |
+| `mariadb.auth.database` | `string` | `panel` | Name of mariadb database to use for panel installation. |
+| `mariadb.auth.username` | `string` | `kubectyl` | User to authenticate to mariadb with. |
+| `mariadb.auth.password` | `string` | `SecretPassword` | Password for user `mariadb.auth.username`. |
+| `mariadb.auth.rootPassword` | `string` | `SuperSecretPassword` | If creating host with chart, password to use for `root` user upon creation. |
+| `mariadb.primary.persistence.size` | `(int)Gi` | `1Gi` | The size of the primary mariadb pod's persistent volume. |
+| `mariadb.secondary.replicaCount` | `int` | `0` | The number of mariadb replicas to create. |
+
+For more in-depth explanation of the configuration and additional options you can specify to the `mariadb` chart, please see [Bitnami's documentation](https://github.com/bitnami/charts/tree/main/bitnami/mariadb).
+
+---
+
+### Redis
+
+| Key  | Type | Default | Description |
+| :--: | :-----------------: | :-----: | ----------- |
+| `redis.create` | `bool` | `true` | Boolean to control creation of redis chart resources. Useful if you plan on using an external redis instance. |
+| `redis.global.storageClass` | `string` | `""` | The storage class to use for the redis persistent volume. To use default K8s storage class set this value to "". |
+| `redis.externalHost` | `string` | `""` | Hostname of external redis instance if you intend to use one. If using built-in redis chart, leave this blank or don't include it at all. |
+| `redis.auth.enabled` | `bool` | `false` | Boolean to control whether we should try to authenticate when connecting to redis. |
+| `redis.auth.password` | `string` | `""` | Password to use for redis authentication. |
+| `redis.master.persistence.size` | `(int)Gi` | `1Gi` | The size of the master redis pod's persistent volume. |
+| `redis.secondary.replicaCount` | `int` | `0` | The number of redis replicas to create. |
+| `redis.sentinel.enabled` | `bool` | `false` | Boolean to enable redis sentinel for high availability. |
+
+For more in-depth explanation of the configuration and additional options you can specify to the `redis` chart, please see [Bitnami's documentation](https://github.com/bitnami/charts/tree/main/bitnami/redis).
+
+---
+
+### Service Account
+
+| Key  | Type | Default | Description |
+| :--: | :-----------------: | :-----: | ----------- |
+| `serviceAccount.create` | `bool` | `true` | Boolean to enable the creation of a service account for our services. |
+| `serviceAccount.name` | `string` | `""` | Name of service account to create. If not set, a name is generated. |
+
+

--- a/charts/kubectyl/templates/certificate.yaml
+++ b/charts/kubectyl/templates/certificate.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.tls.create }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -11,3 +12,4 @@ spec:
   dnsNames:
   - {{ .Values.ingress.panel }}
   - {{ .Values.ingress.kuber }}
+{{- end }}

--- a/charts/kubectyl/templates/configmap.yaml
+++ b/charts/kubectyl/templates/configmap.yaml
@@ -5,17 +5,28 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 data:
   DB_PASSWORD: {{ .Values.mariadb.auth.password }}
+  {{- if .Values.redis.auth.enabled }}
+  REDIS_PASSWORD: {{ .Values.redis.auth.password }}
+  {{- end }}
   APP_URL: https://{{ .Values.ingress.panel }}
   APP_ENV: production
   APP_ENVIRONMENT_ONLY: "false"
-  APP_TIMEZONE: UTC
+  APP_TIMEZONE: {{ .Values.global.timezone | default "UTC" }}
   CACHE_DRIVER: redis
   SESSION_DRIVER: redis
   QUEUE_DRIVER: redis
+  {{- if .Values.redis.externalHost }}
+  REDIS_HOST: {{ .Values.redis.externalHost }}
+  {{- else -}}
   REDIS_HOST: {{ .Release.Name }}-redis-headless
-  DB_HOST: {{ .Release.Name }}-mariadb
-  DB_USERNAME: kubectyl
+  {{- end }}
+  {{- if .Values.mariadb.externalHost }}
+  DB_HOST: {{ .Values.mariadb.externalHost }}
+  {{- else -}}
+  {{- end }}
+  DB_USERNAME: {{ .Values.mariadb.auth.username | default "kubectyl" }}
   DB_PORT: "3306"
+  DB_DATABASE: {{ .Values.mariadb.auth.database | default "panel" }}
   KUBER_FULLNAME: {{ include "kuber.fullname" . }}
   INGRESS_KUBER: {{ .Values.ingress.kuber }}
   INGRESS_PANEL: {{ .Values.ingress.panel }}

--- a/charts/kubectyl/templates/configmap.yaml
+++ b/charts/kubectyl/templates/configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: panel-config
   namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: panel
 data:
   DB_PASSWORD: {{ .Values.mariadb.auth.password }}
   {{- if .Values.redis.auth.enabled }}

--- a/charts/kubectyl/templates/deployment.yaml
+++ b/charts/kubectyl/templates/deployment.yaml
@@ -5,6 +5,12 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     app: kuber
+  {{- with .Values.kuber.deploymentAnnotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   replicas: {{ .Values.kuber.replicaCount }}
   selector:

--- a/charts/kubectyl/templates/deployment.yaml
+++ b/charts/kubectyl/templates/deployment.yaml
@@ -31,6 +31,18 @@ spec:
             mountPath: "/tmp/kubectyl"
           - name: tmp
             mountPath: "/etc/kubectyl"
+      - name: port
+        image: mikefarah/yq
+        command: ["sh", "-c", "yq --inplace '.api.port == \"80\"' /etc/kubectyl/config.yml"]
+        volumeMounts:
+          - name: tmp
+            mountPath: "/etc/kubectyl"
+      - name: disable
+        image: mikefarah/yq
+        command: ["sh", "-c", "yq --inplace '.api.ssl.enabled == \"false\"' /etc/kubectyl/config.yml"]
+        volumeMounts:
+          - name: tmp
+            mountPath: "/etc/kubectyl"
       containers:
       - name: kuber
         image: {{ .Values.kuber.image }}
@@ -40,6 +52,9 @@ spec:
             readOnly: true
           - name: tmp
             mountPath: "/etc/kubectyl"
+        ports:
+        - containerPort: 80
+          name: web
       volumes:
         - name: ssl-certs
           secret:

--- a/charts/kubectyl/templates/ingress.yaml
+++ b/charts/kubectyl/templates/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "panel.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   annotations:
     {{- if .Values.ingress.tls.clusterIssuer }}
@@ -24,7 +24,29 @@ spec:
           service:
             name: {{ include "panel.fullname" . }}
             port:
-              number: 443
+              number: 8081
+  tls:
+    - secretName: {{ include "panel.fullname" . }}-tls
+      hosts:
+      - {{ .Values.ingress.panel }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "kuber.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    {{- if .Values.ingress.tls.clusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
+    {{- end }}
+    {{- if .Values.ingress.annotations }}
+    {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.class }}
+  rules:
   - host: {{ .Values.ingress.kuber }}
     http:
       paths:
@@ -34,9 +56,8 @@ spec:
           service:
             name: {{ include "kuber.fullname" . }}
             port:
-              number: 443
+              number: 8080
   tls:
-    - secretName: {{ .Release.Name }}-tls
+    - secretName: {{ include "kuber.fullname" . }}-tls
       hosts:
-      - {{ .Values.ingress.panel }}
       - {{ .Values.ingress.kuber }}

--- a/charts/kubectyl/templates/ingress.yaml
+++ b/charts/kubectyl/templates/ingress.yaml
@@ -4,13 +4,14 @@ metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace | quote }}
   annotations:
-    {{- if .Values.ingress.clusterIssuer }}
-    cert-manager.io/issuer: {{ .Values.ingress.clusterIssuer }}
+    {{- if .Values.ingress.tls.clusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
     {{- end }}
-    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/proxy-body-size: 100m
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "120s"
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    {{- if .Values.ingress.annotations }}
+    {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.class }}
   rules:

--- a/charts/kubectyl/templates/statefulset.yaml
+++ b/charts/kubectyl/templates/statefulset.yaml
@@ -51,6 +51,12 @@ spec:
         - name: ssl-certs
           secret:
             secretName: {{ .Release.Name }}-tls
+      {{- if and (.Values.panel.existingVolumeClaim) (not .Values.panel.storageClass) }}
+        - name: panel
+          persistentVolumeClaim:
+            claimName: {{ .Values.panel.existingVolumeClaim }}
+      {{- end }}
+  {{- if and (.Values.panel.storageClass) (not .Values.panel.existingVolumeClaim) }}
   volumeClaimTemplates:
   - metadata:
       name: panel
@@ -63,3 +69,4 @@ spec:
       resources:
         requests:
           storage: 1Gi
+  {{- end }}

--- a/charts/kubectyl/templates/statefulset.yaml
+++ b/charts/kubectyl/templates/statefulset.yaml
@@ -3,6 +3,14 @@ kind: StatefulSet
 metadata:
   name: {{ include "panel.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: panel
+  {{- with .Values.panel.statefulSetAnnotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/kubectyl/templates/svc.yaml
+++ b/charts/kubectyl/templates/svc.yaml
@@ -14,7 +14,9 @@ metadata:
 spec:
   ports:
   - name: web
-    port: 443
+    port: 8081
+    protocol: TCP
+    targetPort: 80
   selector:
     app: panel
 ---
@@ -32,7 +34,9 @@ metadata:
   {{- end }}
 spec:
   ports:
-  - name: http
-    port: 443
+  - name: web
+    port: 8080
+    protocol: TCP
+    targetPort: 80
   selector:
     app: kuber

--- a/charts/kubectyl/templates/svc.yaml
+++ b/charts/kubectyl/templates/svc.yaml
@@ -5,6 +5,12 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     app: panel
+  {{- with .Values.panel.serviceAnnotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   ports:
   - name: web
@@ -18,6 +24,12 @@ metadata:
   name: {{ include "kuber.fullname" . }}
   labels:
     app: kuber
+  {{- with .Values.kuber.serviceAnnotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   ports:
   - name: http

--- a/charts/kubectyl/values.yaml
+++ b/charts/kubectyl/values.yaml
@@ -18,6 +18,14 @@ ingress:
     create: true
     # The issuer to use for obtaining TLS certificates
     clusterIssuer: letsencrypt-prod
+  # Extra annotations for ingress resource
+  # nginx known annotations
+  # annotations:
+  #   nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+  #   nginx.ingress.kubernetes.io/proxy-body-size: 100m
+  #   nginx.ingress.kubernetes.io/proxy-read-timeout: "120s"
+  #   nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+  annotations: {}
 panel:
   # The image for the Panel application
   image: quay.io/kubectyl/panel:latest
@@ -26,12 +34,19 @@ panel:
   storageClass: ""
   # The email address for Letsencrypt
   # Used for Panel only as a reference to enable cert-manager
-  email: abc@gmail.com
+  # Annoatations to apply to the Service
+  serviceAnnotations: {}
+  # Annoatations to apply to the StatefulSet
+  statefulSetAnnotations: {}
 kuber:
   # The image for the Kuber application
   image: quay.io/kubectyl/kuber:latest
   # Will be automatically set to 1 after Panel installation
   replicaCount: 0
+  # Annotatations to apply to the Service
+  serviceAnnotations: {}
+  # Annoatations to apply to the Deployment
+  deploymentAnnotations: {}
 mariadb:
   # Boolean to control if chart should create the mariadb deployment
   create: true

--- a/charts/kubectyl/values.yaml
+++ b/charts/kubectyl/values.yaml
@@ -29,9 +29,13 @@ kuber:
   # Will be automatically set to 1 after Panel installation
   replicaCount: 0
 mariadb:
+  # Boolean to control if chart should create the mariadb deployment
+  create: true
   global:
     storageClass: ""
-  # FATAL ERROR: Upgrade failed
+  # Specify external MariaDB host if applicable
+  # Do not use with mariadb.create:true
+  externalHost: ""
   volumePermissions:
     enabled: true
   image:
@@ -53,12 +57,20 @@ mariadb:
     # The number of secondary MariaDB replicas
     replicaCount: 0
 redis:
+  # Boolean to control if chart should create the mariadb deployment
+  create: true
   global:
-    # The global storage class for Redis pods
+    # The storage class to use for redis' persistent volume
+    # To use default K8s storage class set this value to ""
     storageClass: ""
+  # Specify external MariaDB host if applicable
+  # Do not use with mariadb.create:true
+  externalHost: ""
   auth:
     # Enable authentication for Redis
     enabled: false
+    # Password for Redis authentication
+    password: ""
   master:
     persistence:
       # The size of the Redis master pod's persistent volume

--- a/charts/kubectyl/values.yaml
+++ b/charts/kubectyl/values.yaml
@@ -31,7 +31,11 @@ panel:
   image: quay.io/kubectyl/panel:latest
   # The storage class to use for Panel's persistent volume
   # To use default K8s storage class set this value to ""
+  # This is mutually exclusive with panel.existingVolumeClaim
   storageClass: ""
+  # Provide existing volume claim to be used instead of created claim
+  # This is mutually exclusive with panel.storageClass
+  existingVolumeClaim: ""
   # The email address for Letsencrypt
   # Used for Panel only as a reference to enable cert-manager
   # Annoatations to apply to the Service

--- a/charts/kubectyl/values.yaml
+++ b/charts/kubectyl/values.yaml
@@ -5,6 +5,8 @@
 
 ## Overrides for generated resource names
 # See templates/_helpers.tpl
+global:
+  timezone: UTC
 ingress:
   # The Ingress class for routing external traffic to services
   class: nginx
@@ -28,7 +30,7 @@ ingress:
   annotations: {}
 panel:
   # The image for the Panel application
-  image: quay.io/kubectyl/panel:latest
+  image: quay.io/kubectyl/panel:develop
   # The storage class to use for Panel's persistent volume
   # To use default K8s storage class set this value to ""
   # This is mutually exclusive with panel.existingVolumeClaim
@@ -38,13 +40,14 @@ panel:
   existingVolumeClaim: ""
   # The email address for Letsencrypt
   # Used for Panel only as a reference to enable cert-manager
+  email: abc@example.com
   # Annoatations to apply to the Service
   serviceAnnotations: {}
   # Annoatations to apply to the StatefulSet
   statefulSetAnnotations: {}
 kuber:
   # The image for the Kuber application
-  image: quay.io/kubectyl/kuber:latest
+  image: quay.io/kubectyl/kuber:develop
   # Will be automatically set to 1 after Panel installation
   replicaCount: 0
   # Annotatations to apply to the Service

--- a/charts/kubectyl/values.yaml
+++ b/charts/kubectyl/values.yaml
@@ -12,8 +12,12 @@ ingress:
   panel: panel.example.com
   # The hostname for the Kuber application
   kuber: kuber.example.com
-  # The issuer to use for obtaining TLS certificates
-  clusterIssuer: letsencrypt-prod
+  tls:
+    # Boolean to create the certificate resource
+    # false is useful for cert-manager + traefik automation
+    create: true
+    # The issuer to use for obtaining TLS certificates
+    clusterIssuer: letsencrypt-prod
 panel:
   # The image for the Panel application
   image: quay.io/kubectyl/panel:latest


### PR DESCRIPTION
Chart Additions:
 * Ability to specify existing volume claim for panel pods.
 * Ability to use and specify hostname for external mariadb and redis instances. This cancels creation and sourcing of the mariadb and redis subcharts.
   * Adds ability to specify database name and a password for Redis authentication should you choose one.
 * Ability to specify additional annotations for Kubectyl Ingress, Service, StatefulSet, and Deployment resources.
 * Full documentation on all values and defaults available in `values.yaml`.

Chart Fixes:
 * There is no `latest` tag for either the panel or kuber images. This switches them to the correct `develop` tag.
 * Splits ingress to be more sane and match the service resources.
 * Corrects all ports to actually match throughout the stack and no longer requires SSL/HTTPS communication between the service endpoints and the load balancer.
 * Adds some missing labels.
 * Can specify timezone for panel (timezone for kuber still static to `UTC`).

I'll be making another PR on the source to correct the generated Kuber configuration as the above changes alone will need manual follow-up intervention to disable SSL, change the port, and use the correct `sftp-server` image tag.